### PR TITLE
✨ feat: SQ-65626 [react-css] Adicionar props ao componente MenuOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squidit/react-css",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "scripts": {
     "format": "prettier --write --parser typescript '**/*.{ts,tsx}'",
     "lint": "eslint src --ext js,ts,tsx",

--- a/src/components/sq-menu-options/sq-menu-options.component.tsx
+++ b/src/components/sq-menu-options/sq-menu-options.component.tsx
@@ -8,9 +8,19 @@ export interface Props extends React.PropsWithChildren<React.HTMLAttributes<HTML
   placement?: 'left' | 'right'
   icon?: string
   menuArray?: { label: string; icon?: string; iconText?: string; action: () => void }[]
+  styleButton?: React.CSSProperties
+  classButton?: string
 }
 
-export default ({ className = '', children, placement = 'left', menuArray = [], icon = 'ellipsis-vertical' }: Props) => {
+export default ({
+  className = '',
+  children,
+  placement = 'left',
+  menuArray = [],
+  icon = 'ellipsis-vertical',
+  styleButton,
+  classButton = '',
+}: Props) => {
   const [open, setOpen] = useState(false)
   const menuButtonRef = useRef<any>(null)
   const menuRef = useRef(null)
@@ -61,7 +71,13 @@ export default ({ className = '', children, placement = 'left', menuArray = [], 
 
   return (
     <div className={`wrapper-menu ${className}`}>
-      <button onClick={() => setOpen(!open)} className="button-to-open" type="button" ref={menuButtonRef}>
+      <button
+        onClick={() => setOpen(!open)}
+        className={`button-to-open ${classButton}`}
+        type="button"
+        ref={menuButtonRef}
+        style={styleButton}
+      >
         <i className={`fa-regular fa-${icon}`}></i>
       </button>
       <div className={`menu-box box ${placement} ${open ? 'open' : null} scrollbar`} ref={menuRef}>


### PR DESCRIPTION
**Link da Tarefa:**

[SQ-65626](https://duopana.myjetbrains.com/youtrack/issue/SQ-65626/react-css-Adicionar-props-ao-componente-MenuOptions) <!-- Coloque aqui um link para o épico de desenvolvimento ou operação a qual o PR se referencia. -->

- [x] O PR está com o nome no formato **(SQ-12345) Título da Tarefa**
- [x] Foi completamente testado
- [x] Merge do branch **master** foi feito antes do PR ser criado

## Documentação:

- [ ] Criou novos componentes? foi criado a documentação (.md)
- [ ] Criou testes para os novos componentes

## Evidências de Teste:

<!-- Mostre aqui os prints dos testes, ou evidências de funcionamento -->

- [ ] Possui evidências na tarefa
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced button customization in the menu options component with new properties for styling and class application.
	- Users can apply custom styles and CSS classes directly to the button, improving flexibility and presentation control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->