### PR TITLE
SQ-66454 [creators-insights] - Fluxo de modais na ativação do creators-insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squidit/react-css",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "scripts": {
     "format": "prettier --write --parser typescript '**/*.{ts,tsx}'",
     "lint": "eslint src --ext js,ts,tsx",

--- a/src/components-creators-insights/sq-modal-activation/__docs__/sq-modal-activation.component.example.tsx
+++ b/src/components-creators-insights/sq-modal-activation/__docs__/sq-modal-activation.component.example.tsx
@@ -68,6 +68,7 @@ const SqModalActivationExample: React.FC = () => {
           onToggle={handleToggle}
           onConfirm={handleDone}
           onOpenChange={handleOpenChange}
+          requireActiveProfile={true}
         />
       )}
     </div>

--- a/src/components-creators-insights/sq-modal-activation/sq-modal-activation.component.tsx
+++ b/src/components-creators-insights/sq-modal-activation/sq-modal-activation.component.tsx
@@ -23,8 +23,10 @@ export interface Props extends ModalProps {
   onConfirm?: () => void
   onToggle?: (profileId: string, socialNetwork: SocialNetwork, currentState: boolean) => void
   profiles: Profile[]
+  requireActiveProfile?: boolean
 }
-export default ({ profiles, onToggle, onConfirm, onOpenChange, open }: Props) => {
+
+export default ({ profiles, onToggle, onConfirm, onOpenChange, open, requireActiveProfile = false }: Props) => {
   const [width, setWidth] = useState<number>(window.innerWidth)
   const [height, setHeight] = useState<number>(window.innerHeight)
   const { t } = useTranslation('sqModalActivation')
@@ -91,9 +93,19 @@ export default ({ profiles, onToggle, onConfirm, onOpenChange, open }: Props) =>
     </div>
   )
 
+  const isAnyProfileActive = profiles.some((profile) => profile.hasCreatorsInsights)
+
   const footer = (
     <footer className="footer" style={{ width: '100%' }}>
-      <SqButton color="var(--purple-30)" size="lg" borderStyle="none" type="button" width={'100%'} onClick={onConfirm}>
+      <SqButton
+        color="var(--purple-30)"
+        size="lg"
+        borderStyle="none"
+        type="button"
+        width={'100%'}
+        onClick={onConfirm}
+        disabled={requireActiveProfile && !isAnyProfileActive}
+      >
         {t('buttonDone')}
       </SqButton>
     </footer>

--- a/src/components-creators-insights/sq-modal-welcome-creators-insights/sq-modal-welcome-creators-insights.component.tsx
+++ b/src/components-creators-insights/sq-modal-welcome-creators-insights/sq-modal-welcome-creators-insights.component.tsx
@@ -45,9 +45,8 @@ export default ({ className = '', onCloseChange, onConfirm, open, onOpenChange, 
       if (onConfirm && typeof onConfirm === 'function') {
         onConfirm()
       }
-      handleOpenChange(false)
     }
-  }, [activePage, onConfirm, handleOpenChange])
+  }, [activePage, onConfirm])
 
   const handlePrev = useCallback(() => {
     if (activePage > 0) {


### PR DESCRIPTION
**Link da Tarefa:**

[SQ-66454](https://duopana.myjetbrains.com/youtrack/issue/SQ-66454) [creators-insights] - Fluxo de modais na ativação do creators-insights

[](url) <!-- Coloque aqui um link para o épico de desenvolvimento ou operação a qual o PR se referencia. -->

- [x] O PR está com o nome no formato **(SQ-12345) Título da Tarefa**
- [x] Foi completamente testado
- [x] Merge do branch **master** foi feito antes do PR ser criado

## Documentação:

- [ ] Criou novos componentes? foi criado a documentação (.md)
- [ ] Criou testes para os novos componentes

## Evidências de Teste:

 - Botão desabilitado quando não tem nenhum perfil selecionado:

[Screencast from 09-10-2024 15:49:39.webm](https://github.com/user-attachments/assets/645c2cd2-ef34-4930-9acf-876c2371035f)

<!-- Mostre aqui os prints dos testes, ou evidências de funcionamento -->

- [x] Possui evidências na tarefa
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new property, `requireActiveProfile`, to the `SqModalActivation` component, enhancing its functionality by requiring an active profile for proper operation.
	- The footer button behavior is now conditionally disabled based on the active profile status.
	- Improved modal navigation by preventing automatic closure after confirming on the last page.

These updates improve user experience by ensuring that the component only operates when the necessary conditions are met and streamlining interactions within the modal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->