### PR TITLE
(SQ-66445) [creators insights] Bloco de config está em inglês

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@squidit/react-css",
-  "version": "1.1.11",
+  "version": "1.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@squidit/react-css",
-      "version": "1.1.11",
+      "version": "1.1.13",
       "license": "MIT",
       "dependencies": {
         "@storybook/test": "^8.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squidit/react-css",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "scripts": {
     "format": "prettier --write --parser typescript '**/*.{ts,tsx}'",
     "lint": "eslint src --ext js,ts,tsx",

--- a/src/components-creators-insights/sq-modal-activation/sq-modal-activation.component.tsx
+++ b/src/components-creators-insights/sq-modal-activation/sq-modal-activation.component.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import { useState, useEffect, CSSProperties, useCallback } from 'react'
+import { CSSProperties, useCallback, useEffect, useState } from 'react'
 
-import './sq-modal-activation.component.scoped.scss'
 import { SqButton } from '@/src/components/buttons/sq-button'
 import { SqModal } from '@/src/components/sq-modal'
-import { SqSocialConnect } from '../sq-social-connect'
 import { useTranslation } from 'react-i18next'
 import { Props as ModalProps } from '../../components/sq-modal/sq-modal.component'
+import { SqSocialConnect } from '../sq-social-connect'
+import './sq-modal-activation.component.scoped.scss'
 
 type SocialNetwork = 'instagram' | 'youtube' | 'twitter' | 'tiktok'
 
@@ -24,9 +24,22 @@ export interface Props extends ModalProps {
   onToggle?: (profileId: string, socialNetwork: SocialNetwork, currentState: boolean) => void
   profiles: Profile[]
   requireActiveProfile?: boolean
+  titleModal?: string
+  messageModal?: string
+  textButton?: string
 }
 
-export default ({ profiles, onToggle, onConfirm, onOpenChange, open, requireActiveProfile = false }: Props) => {
+export default ({
+  profiles,
+  onToggle,
+  onConfirm,
+  onOpenChange,
+  open,
+  requireActiveProfile = false,
+  titleModal = '',
+  messageModal = '',
+  textButton = '',
+}: Props) => {
   const [width, setWidth] = useState<number>(window.innerWidth)
   const [height, setHeight] = useState<number>(window.innerHeight)
   const { t } = useTranslation('sqModalActivation')
@@ -77,7 +90,7 @@ export default ({ profiles, onToggle, onConfirm, onOpenChange, open, requireActi
 
   const header = (
     <div className="header">
-      <h4>{t('activationQuestion')}</h4>
+      <h4>{titleModal ?? t('activationQuestion')}</h4>
       <SqButton
         color="var(--purple-95)"
         className="button-action rounded"
@@ -106,7 +119,7 @@ export default ({ profiles, onToggle, onConfirm, onOpenChange, open, requireActi
         onClick={onConfirm}
         disabled={requireActiveProfile && !isAnyProfileActive}
       >
-        {t('buttonDone')}
+        {textButton ?? t('buttonDone')}
       </SqButton>
     </footer>
   )
@@ -122,7 +135,7 @@ export default ({ profiles, onToggle, onConfirm, onOpenChange, open, requireActi
       forceMobileNoMargin={true}
     >
       <div className="box-insights">
-        <p dangerouslySetInnerHTML={{ __html: t('insightsText', { socialNetwork: 'instagram' }) }} />
+        <p dangerouslySetInnerHTML={{ __html: messageModal ?? t('insightsText', { socialNetwork: 'instagram' }) }} />
       </div>
       <div
         className="profiles-list"


### PR DESCRIPTION
**Link da Tarefa:**

[SQ-66445](https://duopana.myjetbrains.com/issue/SQ-66445) [creators insights] Bloco de config está em inglês
- [ ] O PR está com o nome no formato **(SQ-12345) Título da Tarefa**
- [ ] Foi completamente testado
- [ ] Merge do branch **master** foi feito antes do PR ser criado

## Documentação:

- [ ] Criou novos componentes? foi criado a documentação (.md)
- [ ] Criou testes para os novos componentes

## Evidências de Teste:

<!-- Mostre aqui os prints dos testes, ou evidências de funcionamento -->

- [ ] Possui evidências na tarefa
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced modal component with customizable properties for title, message, and button text.
	- Modal now conditionally displays provided content or defaults to translations for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->