### PR TITLE
Remove @mclmorais, @marcelo-fernandes-squid from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @JonasPeres @mclmorais @hmkmartini @squidit-master @evertondsantos
+* @JonasPeres  @hmkmartini @squidit-master @evertondsantos


### PR DESCRIPTION
Removes @mclmorais, @marcelo-fernandes-squid from CODEOWNERS entries.

Changes:
- Update `.github/CODEOWNERS`

Generated by the remove-codeowner script.