### PR TITLE
chore: remove @jonasperes from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @JonasPeres  @hmkmartini @squidit-master @evertondsantos
+* @hmkmartini @squidit-master @evertondsantos


### PR DESCRIPTION
## Summary

Remove @jonasperes from CODEOWNERS as part of offboarding / access cleanup.

## Checklist

- [ ] Review that remaining code owners are correct
- [ ] Merge when approved
